### PR TITLE
Investigate mqtt seq number starting value

### DIFF
--- a/esp32_simulator_with_logging.py
+++ b/esp32_simulator_with_logging.py
@@ -5,6 +5,7 @@ import time
 import json
 import base64
 import random
+import uuid
 import numpy as np
 from datetime import datetime
 import logging
@@ -54,7 +55,8 @@ class ESP32Node(threading.Thread):
         self.device_id = device_id
         self.client = mqtt.Client(client_id=f"esp32_{device_id}", protocol=mqtt.MQTTv311)
         self.client.username_pw_set("wspmqtt", "WSP@2025")
-        self.packet_seq = random.randint(10000, 50000)
+        self.packet_seq = 1
+        self.session_id = str(uuid.uuid4())
         self.connected = False
         self.try_connect()
 
@@ -98,6 +100,7 @@ class ESP32Node(threading.Thread):
             "data": ecg_data_b64,
             "packet_id": f"{time.time()}.{self.device_id}.{self.packet_seq}",
             "seq_no": self.packet_seq,
+            "session_id": self.session_id,
             "battery": battery,
             "sample_rate": SAMPLE_RATE,
             "lead_status": lead_status,


### PR DESCRIPTION
Start `seq_no` from 1 and add a `session_id` to MQTT payloads.

Previously, `seq_no` started from a random value, causing ambiguity about whether initial data was missed or if the first recorded `seq_no` was merely a random starting point. This change ensures that the first message of each device-session is `seq_no = 1`, and the `session_id` provides a clear identifier for segmenting runs in the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-1507e4ad-bfc3-40c8-bde0-3486905e2849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1507e4ad-bfc3-40c8-bde0-3486905e2849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

